### PR TITLE
Move properties to enviroment vars

### DIFF
--- a/src/main/scala-2.11/org/romeo/loveletter/http/Properties.scala
+++ b/src/main/scala-2.11/org/romeo/loveletter/http/Properties.scala
@@ -1,0 +1,11 @@
+package org.romeo.loveletter.http
+
+/**
+  * Created by tylerromeo on 2/13/17.
+  */
+object Properties {
+
+  def port: Int = scala.util.Properties.envOrElse("PORT", "8080").toInt
+  def commandToken: Option[String] = scala.util.Properties.envOrNone("SLACK_COMMAND_TOKEN")
+
+}


### PR DESCRIPTION
Add a separate file for tracking environment variables. Move the port to this file, and also the value of the slack team token.

Ordinarily i'd have these in a config file in resources, but heroku really likes environment variables.

fixes #2 